### PR TITLE
tags extension

### DIFF
--- a/elephantblog/extensions/tags.py
+++ b/elephantblog/extensions/tags.py
@@ -1,4 +1,3 @@
-
 from django.utils.translation import ugettext_lazy as _
 
 try:
@@ -9,4 +8,4 @@ except ImportError:
 def register(cls, admin_cls):
     cls.add_to_class('tags', TaggableManager(
         help_text=_('A comma-separated list of tags.')))
-        admin_cls.fieldsets[0][1].get('fields').append('tags')
+    admin_cls.fieldsets[0][1].get('fields').append('tags')


### PR DESCRIPTION
The 'tags' field wouldn't appear in backend before. I just added one line. It should be self explanatory.
