### PR TITLE
Blog as app content did not work because of missing request context

### DIFF
--- a/elephantblog/views.py
+++ b/elephantblog/views.py
@@ -1,4 +1,6 @@
 from django.shortcuts import get_object_or_404
+from django.shortcuts import render_to_response
+from django.template import RequestContext
 from django.utils.cache import add_never_cache_headers
 from django.views.generic import dates
 


### PR DESCRIPTION
Made modification to render_to_response of ElephantblogMixin to get templates from content/ and use RequestContext.
