### PR TITLE
Adding Django 1.7+ compatible migrations

### DIFF
--- a/elephantblog/migrations/0001_initial.py
+++ b/elephantblog/migrations/0001_initial.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import feincms.module.mixins
+import feincms.extensions
+import feincms.translations
+import django.utils.timezone
+from django.conf import settings
+import feincms.contrib.richtext
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Category',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('ordering', models.SmallIntegerField(default=0, verbose_name='ordering')),
+            ],
+            options={
+                'ordering': ['ordering'],
+                'verbose_name': 'category',
+                'verbose_name_plural': 'categories',
+            },
+            bases=(models.Model, feincms.translations.TranslatedObjectMixin),
+        ),
+        migrations.CreateModel(
+            name='CategoryTranslation',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('language_code', models.CharField(default=b'af', max_length=10, verbose_name='language', choices=[(b'af', b'Afrikaans'), (b'ar', b'Arabic'), (b'ast', b'Asturian'), (b'az', b'Azerbaijani'), (b'bg', b'Bulgarian'), (b'be', b'Belarusian'), (b'bn', b'Bengali'), (b'br', b'Breton'), (b'bs', b'Bosnian'), (b'ca', b'Catalan'), (b'cs', b'Czech'), (b'cy', b'Welsh'), (b'da', b'Danish'), (b'de', b'German'), (b'el', b'Greek'), (b'en', b'English'), (b'en-au', b'Australian English'), (b'en-gb', b'British English'), (b'eo', b'Esperanto'), (b'es', b'Spanish'), (b'es-ar', b'Argentinian Spanish'), (b'es-mx', b'Mexican Spanish'), (b'es-ni', b'Nicaraguan Spanish'), (b'es-ve', b'Venezuelan Spanish'), (b'et', b'Estonian'), (b'eu', b'Basque'), (b'fa', b'Persian'), (b'fi', b'Finnish'), (b'fr', b'French'), (b'fy', b'Frisian'), (b'ga', b'Irish'), (b'gl', b'Galician'), (b'he', b'Hebrew'), (b'hi', b'Hindi'), (b'hr', b'Croatian'), (b'hu', b'Hungarian'), (b'ia', b'Interlingua'), (b'id', b'Indonesian'), (b'io', b'Ido'), (b'is', b'Icelandic'), (b'it', b'Italian'), (b'ja', b'Japanese'), (b'ka', b'Georgian'), (b'kk', b'Kazakh'), (b'km', b'Khmer'), (b'kn', b'Kannada'), (b'ko', b'Korean'), (b'lb', b'Luxembourgish'), (b'lt', b'Lithuanian'), (b'lv', b'Latvian'), (b'mk', b'Macedonian'), (b'ml', b'Malayalam'), (b'mn', b'Mongolian'), (b'mr', b'Marathi'), (b'my', b'Burmese'), (b'nb', b'Norwegian Bokmal'), (b'ne', b'Nepali'), (b'nl', b'Dutch'), (b'nn', b'Norwegian Nynorsk'), (b'os', b'Ossetic'), (b'pa', b'Punjabi'), (b'pl', b'Polish'), (b'pt', b'Portuguese'), (b'pt-br', b'Brazilian Portuguese'), (b'ro', b'Romanian'), (b'ru', b'Russian'), (b'sk', b'Slovak'), (b'sl', b'Slovenian'), (b'sq', b'Albanian'), (b'sr', b'Serbian'), (b'sr-latn', b'Serbian Latin'), (b'sv', b'Swedish'), (b'sw', b'Swahili'), (b'ta', b'Tamil'), (b'te', b'Telugu'), (b'th', b'Thai'), (b'tr', b'Turkish'), (b'tt', b'Tatar'), (b'udm', b'Udmurt'), (b'uk', b'Ukrainian'), (b'ur', b'Urdu'), (b'vi', b'Vietnamese'), (b'zh-cn', b'Simplified Chinese'), (b'zh-hans', b'Simplified Chinese'), (b'zh-hant', b'Traditional Chinese'), (b'zh-tw', b'Traditional Chinese')])),
+                ('title', models.CharField(max_length=100, verbose_name='category title')),
+                ('slug', models.SlugField(unique=True, verbose_name='slug')),
+                ('description', models.CharField(max_length=250, verbose_name='description', blank=True)),
+                ('parent', models.ForeignKey(related_name='translations', to='elephantblog.Category')),
+            ],
+            options={
+                'ordering': ['title'],
+                'verbose_name': 'category translation',
+                'verbose_name_plural': 'category translations',
+            },
+        ),
+        migrations.CreateModel(
+            name='Entry',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('is_active', models.BooleanField(default=True, db_index=True, verbose_name='is active')),
+                ('is_featured', models.BooleanField(default=False, db_index=True, verbose_name='is featured')),
+                ('title', models.CharField(max_length=100, verbose_name='title')),
+                ('slug', models.SlugField(max_length=100, verbose_name='slug', unique_for_date='published_on')),
+                ('published_on', models.DateTimeField(default=django.utils.timezone.now, blank=True, help_text='Will be filled in automatically when entry gets published.', null=True, verbose_name='published on', db_index=True)),
+                ('last_changed', models.DateTimeField(auto_now=True, verbose_name='last change')),
+                ('author', models.ForeignKey(related_name='blogentries', verbose_name='author', to=settings.AUTH_USER_MODEL)),
+                ('categories', models.ManyToManyField(related_name='blogentries', null=True, verbose_name='categories', to='elephantblog.Category', blank=True)),
+            ],
+            options={
+                'ordering': ['-published_on'],
+                'get_latest_by': 'published_on',
+                'verbose_name': 'entry',
+                'verbose_name_plural': 'entries',
+            },
+            bases=(models.Model, feincms.extensions.ExtensionsMixin, feincms.module.mixins.ContentModelMixin),
+        ),
+        migrations.CreateModel(
+            name='ImageContent',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('image', models.ImageField(upload_to='imagecontent', max_length=255, verbose_name='image')),
+                ('alt_text', models.CharField(help_text='Description of image', max_length=255, verbose_name='alternate text', blank=True)),
+                ('caption', models.CharField(max_length=255, verbose_name='caption', blank=True)),
+                ('region', models.CharField(max_length=255)),
+                ('ordering', models.IntegerField(default=0, verbose_name='ordering')),
+                ('parent', models.ForeignKey(related_name='imagecontent_set', to='elephantblog.Entry')),
+            ],
+            options={
+                'ordering': ['ordering'],
+                'abstract': False,
+                'verbose_name_plural': 'images',
+                'db_table': 'elephantblog_entry_imagecontent',
+                'verbose_name': 'image',
+                'permissions': [],
+            },
+        ),
+        migrations.CreateModel(
+            name='RawContent',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('text', models.TextField(verbose_name='content', blank=True)),
+                ('region', models.CharField(max_length=255)),
+                ('ordering', models.IntegerField(default=0, verbose_name='ordering')),
+                ('parent', models.ForeignKey(related_name='rawcontent_set', to='elephantblog.Entry')),
+            ],
+            options={
+                'ordering': ['ordering'],
+                'abstract': False,
+                'verbose_name_plural': 'raw contents',
+                'db_table': 'elephantblog_entry_rawcontent',
+                'verbose_name': 'raw content',
+                'permissions': [],
+            },
+        ),
+        migrations.CreateModel(
+            name='RichTextContent',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('text', feincms.contrib.richtext.RichTextField(verbose_name='text', blank=True)),
+                ('region', models.CharField(max_length=255)),
+                ('ordering', models.IntegerField(default=0, verbose_name='ordering')),
+                ('parent', models.ForeignKey(related_name='richtextcontent_set', to='elephantblog.Entry')),
+            ],
+            options={
+                'ordering': ['ordering'],
+                'abstract': False,
+                'verbose_name_plural': 'rich texts',
+                'db_table': 'elephantblog_entry_richtextcontent',
+                'verbose_name': 'rich text',
+                'permissions': [],
+            },
+        ),
+        migrations.CreateModel(
+            name='VideoContent',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('video', models.URLField(help_text='This should be a link to a youtube or vimeo video, i.e.: http://www.youtube.com/watch?v=zmj1rpzDRZ0', verbose_name='video link')),
+                ('region', models.CharField(max_length=255)),
+                ('ordering', models.IntegerField(default=0, verbose_name='ordering')),
+                ('parent', models.ForeignKey(related_name='videocontent_set', to='elephantblog.Entry')),
+            ],
+            options={
+                'ordering': ['ordering'],
+                'abstract': False,
+                'verbose_name_plural': 'videos',
+                'db_table': 'elephantblog_entry_videocontent',
+                'verbose_name': 'video',
+                'permissions': [],
+            },
+        ),
+    ]


### PR DESCRIPTION
This fixes issues when the user model is overridden.
Due to an issue with the Django migration system, all apps without South/Django migrations are run first.
Given that the dependency for the custom user model is not yet set up, the migration of feincms-elephantblog will always fail.