### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Read the source: https://github.com/feincms/feincms-elephantblog
 
 .. image:: https://travis-ci.org/feincms/feincms-elephantblog.png?branch=master
    :target: https://travis-ci.org/feincms/feincms-elephantblog
-.. image:: https://pypip.in/wheel/feincms-elephantblog/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/feincms-elephantblog.svg
     :target: https://pypi.python.org/pypi/feincms-elephantblog/
     :alt: Wheel Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20feincms-elephantblog))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `feincms-elephantblog`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.